### PR TITLE
Internal http client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: go
+go:
+  - "1.13.x"
+
+script:
+  - go test -v -race $(go list ./...)
+  - go vet $(go list ./...)
+  - (for d in $(go list ./...); do diff <(golint $d) <(printf "") || exit 1;  done)
+
+#TODO add slack hook
+#notifications:
+#  slack: `<account>:<token>#channel`

--- a/client/authorizer.go
+++ b/client/authorizer.go
@@ -1,0 +1,31 @@
+package client
+
+import (
+	"fmt"
+	"net/http"
+)
+
+const (
+	bearerTokenAuthorization = "Authorization"
+)
+
+// Authorizer defines a way to retrieve Credentials
+type Authorizer interface {
+	// AuthorizeRequest is an implementation provided to make
+	// credentials signing pluggable and customizable.
+	//
+	// A default bearer token implementation is provided.
+	AuthorizeRequest(r *http.Request)
+}
+
+// BearerTokenAuthorizer represents the basic inputs for token authorization.
+type BearerTokenAuthorizer struct {
+	Token string
+}
+
+// AuthorizeRequest sets a  pre-configured token value on the request header.
+func (b *BearerTokenAuthorizer) AuthorizeRequest(r *http.Request) {
+	if b.Token != "" {
+		r.Header.Set(bearerTokenAuthorization, fmt.Sprintf("Bearer %s", b.Token))
+	}
+}

--- a/client/authorizer_test.go
+++ b/client/authorizer_test.go
@@ -1,0 +1,20 @@
+package client
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_AuthorizeRequest(t *testing.T) {
+	b := &BearerTokenAuthorizer{
+		Token: "password",
+	}
+
+	assert := assert.New(t)
+	r, _ := http.NewRequest("GET", "", nil)
+	b.AuthorizeRequest(r)
+	token := r.Header.Get(bearerTokenAuthorization)
+	assert.Equal(token, "Bearer password")
+}

--- a/client/client.go
+++ b/client/client.go
@@ -1,0 +1,115 @@
+package client
+
+import (
+	"io"
+	"net/http"
+	"time"
+)
+
+const (
+	maxDefaultRetries = 3
+)
+
+// These values are derived from the default values of DefaultTransport and
+// Transport respectively from net/http/transport.go
+var (
+	defaultRequestTimeout      = 30 * time.Second
+	defaultTLSHandshakeTimeout = 10 * time.Second
+	defaultMaxIdleConns        = 100
+	defaultMaxIdleConnsPerHost = 2
+	defaultIdleConnTimeout     = 90 * time.Second
+)
+
+// Client implements the base client request and response handling
+// used by all service clients.
+type Client struct {
+	Authorizer Authorizer
+	Retryer    Retryer
+
+	httpClient *http.Client
+	baseURL    string
+}
+
+// NewClient returns a new instance of sdk.Client.
+// The config gets sanitized by returning a copy of the passed configuration
+// with default set if the given values are not set by the caller.
+// The default values are derived from the default values of DefaultTransport
+// and Transport respectively from net/http/transport.go
+func NewClient(config Config) *Client {
+	config = sanitize(config)
+
+	httpClient := newHTTPClient(config)
+
+	client := &Client{
+		baseURL:    config.BaseURL,
+		httpClient: httpClient,
+		Retryer:    config.Retryer,
+		Authorizer: config.Authorizer,
+	}
+
+	return client
+}
+
+// sanitize is some space shuttle code that enables configuration to be
+// easy.
+func sanitize(config Config) Config {
+	sanitized := Config{
+		Authorizer: config.Authorizer,
+		BaseURL:    config.BaseURL,
+	}
+	sanitized.Retryer = config.Retryer
+	if config.Retryer == nil {
+		sanitized.Retryer = DefaultRetryer{NumMaxRetries: maxDefaultRetries}
+	}
+
+	sanitized.RequestTimeout = &defaultRequestTimeout
+	if config.RequestTimeout != nil {
+		sanitized.RequestTimeout = config.RequestTimeout
+	}
+	sanitized.TLSHandshakeTimeout = &defaultTLSHandshakeTimeout
+	if config.TLSHandshakeTimeout != nil {
+		sanitized.TLSHandshakeTimeout = config.TLSHandshakeTimeout
+	}
+	sanitized.MaxIdleConns = &defaultMaxIdleConns
+	if config.MaxIdleConns != nil {
+		sanitized.MaxIdleConns = config.MaxIdleConns
+	}
+	sanitized.MaxIdleConnsPerHost = &defaultMaxIdleConnsPerHost
+	if config.MaxIdleConnsPerHost != nil {
+		sanitized.MaxIdleConnsPerHost = config.MaxIdleConnsPerHost
+	}
+	sanitized.IdleConnTimeout = &defaultIdleConnTimeout
+	if config.IdleConnTimeout != nil {
+		sanitized.IdleConnTimeout = config.IdleConnTimeout
+	}
+	return sanitized
+}
+
+// newHTTPClient creates a HTTP client based on go's http.DefaultClient and
+// http.DefaultTransport.
+func newHTTPClient(config Config) *http.Client {
+	defaultTransport, _ := http.DefaultTransport.(*http.Transport)
+
+	defaultTransport.TLSHandshakeTimeout = *config.TLSHandshakeTimeout
+	defaultTransport.MaxIdleConns = *config.MaxIdleConns
+	defaultTransport.MaxIdleConnsPerHost = *config.MaxIdleConnsPerHost
+	defaultTransport.IdleConnTimeout = *config.IdleConnTimeout
+
+	client := http.DefaultClient
+	client.Transport = defaultTransport
+	client.Timeout = *config.RequestTimeout
+	return client
+}
+
+// NewRequest is to get a new Request option tied to a client
+func (c *Client) NewRequest(op Operation, output interface{},
+	body io.ReadSeeker, paramsList ...map[string]string) (*Request, error) {
+	var params map[string]string
+	if len(paramsList) == 0 {
+		params = nil
+	} else {
+		params = paramsList[0]
+	}
+	return NewRequest(c.httpClient, c.Retryer, c.Authorizer, c.baseURL, op,
+		output, body, params)
+}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,0 +1,86 @@
+package client
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type mockRetryer struct{}
+
+func (m *mockRetryer) RetryRules(*Request) time.Duration {
+	return 1 * time.Second
+}
+
+func (m *mockRetryer) ShouldRetry(*Request) bool {
+	return true
+}
+
+func (m *mockRetryer) MaxRetries() int {
+	return 42
+}
+
+type mockAuthorizer struct{}
+
+func (m *mockAuthorizer) AuthorizeRequest(r *http.Request) {
+	r.Header.Set("Authorization", "Yes")
+}
+
+func TestSanitizeConfig(t *testing.T) {
+	mr := &mockRetryer{}
+	ma := &mockAuthorizer{}
+
+	tests := []struct {
+		desc     string
+		config   Config
+		expected Config
+	}{
+		{
+			desc: "minimal config gets set with default values",
+			config: Config{
+				BaseURL: "http://base.url",
+			},
+			expected: Config{
+				Retryer:             DefaultRetryer{NumMaxRetries: maxDefaultRetries},
+				Authorizer:          nil,
+				BaseURL:             "http://base.url",
+				RequestTimeout:      &defaultRequestTimeout,
+				TLSHandshakeTimeout: &defaultTLSHandshakeTimeout,
+				MaxIdleConns:        &defaultMaxIdleConns,
+				MaxIdleConnsPerHost: &defaultMaxIdleConnsPerHost,
+				IdleConnTimeout:     &defaultIdleConnTimeout,
+			},
+		},
+		{
+			desc: "fully set config respects the values",
+			config: Config{
+				Retryer:             mr,
+				Authorizer:          ma,
+				BaseURL:             "http://base.url",
+				RequestTimeout:      Duration(2 * time.Second),
+				TLSHandshakeTimeout: Duration(3 * time.Second),
+				MaxIdleConns:        Int(42),
+				MaxIdleConnsPerHost: Int(73),
+				IdleConnTimeout:     Duration(4 * time.Second),
+			},
+			expected: Config{
+				Retryer:             mr,
+				Authorizer:          ma,
+				BaseURL:             "http://base.url",
+				RequestTimeout:      Duration(2 * time.Second),
+				TLSHandshakeTimeout: Duration(3 * time.Second),
+				MaxIdleConns:        Int(42),
+				MaxIdleConnsPerHost: Int(73),
+				IdleConnTimeout:     Duration(4 * time.Second),
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			actual := sanitize(test.config)
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}

--- a/client/config.go
+++ b/client/config.go
@@ -1,0 +1,29 @@
+package client
+
+import (
+	"time"
+)
+
+// Config holds any all extensible and configurable features.
+type Config struct {
+	Retryer    Retryer
+	Authorizer Authorizer
+	BaseURL    string
+
+	// used to fine-tune the underlying transport of the HTTP client.
+	RequestTimeout      *time.Duration
+	TLSHandshakeTimeout *time.Duration
+	MaxIdleConns        *int
+	MaxIdleConnsPerHost *int
+	IdleConnTimeout     *time.Duration
+}
+
+// Int is a helper to set the pointer based config values above.
+func Int(i int) *int {
+	return &i
+}
+
+// Duration is a helper to set the pointer based config values above.
+func Duration(t time.Duration) *time.Duration {
+	return &t
+}

--- a/client/errors.go
+++ b/client/errors.go
@@ -1,0 +1,134 @@
+package client
+
+import (
+	"fmt"
+)
+
+type ErrorCode string
+
+const (
+	ErrCodeTimeout         = "timeout"
+	ErrCodeNotFound        = "not_found"
+	ErrCodeUnmarshalFailed = "unmarshal_failed"
+
+	// ErrCodeUndefined is for generic unknown/unexpected errors.
+	ErrCodeUndefined = "unknown"
+)
+
+// RFError wraps the lower level errors wit a code, message and original error.
+// RF stands for RouteFusion.
+type RFError interface {
+	// Satisfy the generic error interface.
+	error
+
+	// Returns the short phrase depicting the classification of the error.
+	Code() string
+
+	// Returns the error details message.
+	Message() string
+
+	// Returns the original error if one was set.  Nil is returned if not set.
+	OrigErr() error
+}
+
+func NewRFError(code string, message string, origErr error) RFError {
+	return newBaseError(code, message, origErr)
+}
+
+type RequestFailureError interface {
+	RFError
+
+	// The status code of the HTTP response.
+	StatusCode() int
+
+	// The request ID returned by the service for a request failure. This will
+	// be empty if no request ID is available such as the request failed due
+	// to a connection error.
+	RequestID() string
+}
+
+func NewRequestFailureError(err RFError, statusCode int, reqID string) RequestFailureError {
+	return newRequestError(err, statusCode, reqID)
+}
+
+func printError(code, message, extra string, origErr error) string {
+	msg := fmt.Sprintf("%s: %s", code, message)
+	if extra != "" {
+		msg = fmt.Sprintf("%s\n\t%s", msg, extra)
+	}
+
+	if origErr != nil {
+		msg = fmt.Sprintf("%s\n caused by: %s", msg, origErr.Error())
+	}
+	return msg
+}
+
+type baseError struct {
+	code    string
+	message string
+	origErr error
+}
+
+func newBaseError(code string, message string, origErr error) *baseError {
+	return &baseError{
+		code:    code,
+		message: message,
+		origErr: origErr,
+	}
+}
+
+func (b baseError) Error() string {
+	return printError(b.code, b.message, "", nil)
+}
+
+func (b baseError) String() string {
+	return b.Error()
+}
+
+func (b baseError) Code() string {
+	return b.code
+}
+
+func (b baseError) Message() string {
+	return b.message
+}
+
+func (b baseError) OrigErr() error {
+	return b.origErr
+}
+
+type requestError struct {
+	RFError
+	statusCode int
+	requestID  string
+}
+
+func newRequestError(err RFError, statusCode int, requestID string) *requestError {
+	return &requestError{
+		RFError:    err,
+		statusCode: statusCode,
+		requestID:  requestID,
+	}
+}
+
+func (r requestError) Error() string {
+	extra := fmt.Sprintf("status code: %d, request id: %s",
+		r.statusCode, r.requestID)
+	return printError(r.Code(), r.Message(), extra, r.OrigErr())
+}
+
+func (r requestError) String() string {
+	return r.Error()
+}
+
+func (r requestError) StatusCode() int {
+	return r.statusCode
+}
+
+func (r requestError) RequestID() string {
+	return r.requestID
+}
+
+func (r requestError) OrigErrs() []error {
+	return []error{r.OrigErr()}
+}

--- a/client/errors_test.go
+++ b/client/errors_test.go
@@ -1,0 +1,57 @@
+package client
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_PrintError(t *testing.T) {
+	var tests = []struct {
+		desc           string
+		code           string
+		msg            string
+		extra          string
+		origErr        error
+		expectedOutput string
+	}{
+		{
+			desc:           "all fields provided",
+			code:           ErrCodeTimeout,
+			msg:            "some failure message",
+			extra:          "more stuff",
+			origErr:        errors.New("Mayday mayday mayday"),
+			expectedOutput: "timeout: some failure message\n\tmore stuff\n caused by: Mayday mayday mayday",
+		},
+		{
+			desc:           "error not provided",
+			code:           ErrCodeTimeout,
+			msg:            "some failure message",
+			extra:          "more stuff",
+			expectedOutput: "timeout: some failure message\n\tmore stuff",
+		},
+		{
+			desc:           "extra not provided",
+			code:           ErrCodeTimeout,
+			msg:            "some failure message",
+			origErr:        errors.New("Mayday mayday mayday"),
+			expectedOutput: "timeout: some failure message\n caused by: Mayday mayday mayday",
+		},
+		{
+			desc:           "only the code and msg are provided",
+			code:           ErrCodeTimeout,
+			msg:            "some failure message",
+			expectedOutput: "timeout: some failure message",
+		},
+	}
+
+	for _, testcase := range tests {
+		t.Run(testcase.desc, func(t *testing.T) {
+			assert := assert.New(t)
+			op := printError(testcase.code, testcase.msg, testcase.extra, testcase.origErr)
+			assert.Equal(testcase.expectedOutput, op)
+		})
+	}
+
+}

--- a/client/request.go
+++ b/client/request.go
@@ -1,0 +1,186 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"path"
+	"sync"
+	"time"
+)
+
+const (
+	requestHeaderKeyAccept = "Accept"
+)
+
+// A Request is the service request to be made.
+type Request struct {
+	sync.Mutex
+
+	HTTPRequest  *http.Request
+	HTTPResponse *http.Response
+	Error        RequestFailureError
+	Output       interface{}
+	Retryer      Retryer
+	RetryCount   int
+
+	body   io.ReadSeeker
+	client *http.Client
+}
+
+// An Operation is the service API operation to be made
+type Operation struct {
+	HTTPMethod string
+	HTTPPath   string
+}
+
+// NewRequest returns a new request. It is intended to be a shoot once and forget
+// object. While Send() is threadsafe, multiple calls in goroutines
+// for a single Request will not make sense because it retries inherently.
+func NewRequest(client *http.Client,
+	retryer Retryer,
+	authorizer Authorizer,
+	baseURL string,
+	op Operation,
+	output interface{},
+	body io.ReadSeeker,
+	params map[string]string) (*Request, error) {
+
+	finalURL, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid endpoint or HTTPPath supplied: %s", err)
+	}
+
+	finalURL.Path = path.Join(finalURL.Path, op.HTTPPath)
+	httpReq, err := http.NewRequest(op.HTTPMethod, finalURL.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("error making new request: %s", err)
+	}
+	if authorizer != nil {
+		authorizer.AuthorizeRequest(httpReq)
+	}
+	unpackParams(httpReq, params)
+
+	return &Request{
+		Output:      output,
+		HTTPRequest: httpReq,
+		body:        body,
+		Retryer:     retryer,
+		client:      client,
+	}, nil
+}
+
+// Send makes the actual request. It's got a retryer built in that
+// employs customizable retry logic for a configurable finite number
+// of attempts.
+// An error message of format `http request failed after 0 attempts: ...` means
+// that at least one regular HTTP request but no (zero) further attempts were made.
+func (r *Request) Send() (err error) {
+	r.Lock()
+	defer r.Unlock()
+
+	for try := 0; ; try++ {
+		if r.body != nil {
+			r.HTTPRequest.Body = newOffsetReader(r.body, 0)
+		}
+
+		r.HTTPResponse, err = r.client.Do(r.HTTPRequest)
+
+		if r.Retryer.ShouldRetry(r) && try < r.Retryer.MaxRetries() {
+			r.RetryCount++
+			time.Sleep(r.Retryer.RetryRules(r))
+			continue
+		}
+
+		if err != nil {
+			code := ErrCodeUndefined
+			msg := fmt.Sprintf("http request failed after %d attempts", try)
+			if uerr, ok := err.(*url.Error); ok && uerr.Timeout() {
+				code = ErrCodeTimeout
+			}
+			return NewRequestFailureError(NewRFError(code, msg, err), 0, "")
+		}
+
+		if r.HTTPResponse.StatusCode < http.StatusOK ||
+			r.HTTPResponse.StatusCode > http.StatusIMUsed {
+			msg := fmt.Sprintf("http request failed after %d attempts", try)
+			if r.HTTPResponse.StatusCode == http.StatusNotFound {
+				if r.HTTPResponse != nil {
+					r.HTTPResponse.Body.Close()
+				}
+				return NewRequestFailureError(NewRFError(
+					ErrCodeNotFound, msg, nil),
+					r.HTTPResponse.StatusCode,
+					"")
+			}
+
+			return NewRequestFailureError(
+				NewRFError(ErrCodeUndefined, msg, err),
+				r.HTTPResponse.StatusCode,
+				"")
+		}
+
+		if r.Output != nil {
+			err = r.unmarshalBody()
+			if err != nil {
+				return NewRequestFailureError(
+					NewRFError(ErrCodeUnmarshalFailed, "unmarshal failed", err),
+					r.HTTPResponse.StatusCode,
+					"")
+			}
+		}
+
+		return nil
+	}
+}
+
+func (r *Request) readBody() ([]byte, error) {
+	p, err := ioutil.ReadAll(r.HTTPResponse.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading response body: %s", err)
+	}
+	defer r.HTTPResponse.Body.Close()
+	return p, nil
+}
+
+func (r *Request) unmarshalBody() error {
+	defer r.HTTPResponse.Body.Close()
+
+	acceptHeader := r.HTTPRequest.Header.Get(requestHeaderKeyAccept)
+
+	unmarshaler, ok := unmarshalers[acceptHeader]
+	if ok {
+		return unmarshaler.Unmarshal(r.HTTPResponse.Body, r.Output)
+	}
+
+	return json.NewDecoder(r.HTTPResponse.Body).Decode(r.Output)
+}
+
+func unpackParams(r *http.Request, params map[string]string) {
+	q := r.URL.Query()
+	for paramName, paramValue := range params {
+		q.Add(paramName, paramValue)
+	}
+	r.URL.RawQuery = q.Encode()
+}
+
+// MergeRequestHeader merges the given headers but ignores multi-values and
+// therefore overwrites the slice of header values with the new slice.
+func MergeRequestHeader(h1, h2 http.Header) http.Header {
+	headers := make(http.Header, len(h1))
+	for k, v1 := range h1 {
+		headers[k] = v1
+		if v2, ok := h2[k]; ok {
+			headers[k] = v2
+		}
+	}
+
+	for k, v2 := range h2 {
+		headers[k] = v2
+	}
+
+	return headers
+}

--- a/client/request_test.go
+++ b/client/request_test.go
@@ -1,0 +1,163 @@
+package client
+
+import (
+	"errors"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type basicOutputType struct {
+	ID      int    `json:"id"`
+	Created string `json:"created"`
+}
+
+func Test_Send(t *testing.T) {
+	testCases := []struct {
+		desc               string
+		statusCode         int
+		method             string
+		path               string
+		params             map[string]string
+		response           []byte
+		body               io.ReadSeeker
+		expectedURL        string
+		expectedErr        RequestFailureError
+		expectedReqBody    []byte
+		expectedOP         *basicOutputType
+		forceHTTPClientErr bool
+	}{
+		{
+			desc:        "basic 200 returns no error and the response message",
+			statusCode:  200,
+			method:      "GET",
+			path:        "/test/path",
+			response:    []byte(`{"id" : 123, "created" : "true"}`),
+			expectedErr: nil,
+			expectedURL: "/test/path",
+			expectedOP:  &basicOutputType{ID: 123, Created: "true"},
+		},
+		{
+			desc:       "503 error returns an error message after retrying",
+			statusCode: 503,
+			method:     "GET",
+			path:       "/test/path",
+			response:   []byte(`{"error_code": 503, "error_message": "service unavailable"}`),
+			expectedErr: &requestError{RFError: newBaseError(ErrCodeUndefined, "http request failed after 3 attempts", nil),
+				statusCode: 503, requestID: ""},
+			body:            strings.NewReader(`{"somebody": "bodyval"}`),
+			expectedReqBody: []byte(`{"somebody": "bodyval"}`),
+			expectedURL:     "/test/path",
+			expectedOP:      &basicOutputType{},
+		},
+		{
+			desc:            "400 error returns an error message after 0 retries",
+			statusCode:      400,
+			method:          "GET",
+			path:            "/test/path",
+			response:        []byte(`{"error_code": 400, "error_message": "bad request"}`),
+			expectedErr:     &requestError{RFError: newBaseError(ErrCodeUndefined, "http request failed after 0 attempts", nil), statusCode: 400, requestID: ""},
+			body:            nil,
+			expectedReqBody: nil,
+			expectedURL:     "/test/path",
+			expectedOP:      &basicOutputType{},
+		},
+		{
+			desc:        "basic 200 returns no error and the response message with Params",
+			statusCode:  200,
+			method:      "GET",
+			path:        "/test/path",
+			response:    []byte(`{"id" : 223, "created" : "true"}`),
+			params:      map[string]string{"query-1": "123", "query-2": "something-else"},
+			expectedErr: nil,
+			expectedURL: "/test/path?query-1=123&query-2=something-else",
+			expectedOP:  &basicOutputType{ID: 223, Created: "true"},
+		},
+		{
+			desc:               "http client returns error",
+			statusCode:         0,
+			method:             "GET",
+			path:               "/test/path",
+			response:           nil,
+			expectedErr:        &requestError{RFError: newBaseError(ErrCodeUndefined, "http request failed after 0 attempts", errors.New("Get : http: nil Request.URL")), statusCode: 0, requestID: ""},
+			body:               nil,
+			expectedReqBody:    nil,
+			expectedURL:        "/test/path",
+			expectedOP:         &basicOutputType{},
+			forceHTTPClientErr: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.desc, func(t *testing.T) {
+			var op = &basicOutputType{}
+
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter,
+				r *http.Request) {
+				bdy, err := ioutil.ReadAll(r.Body)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !reflect.DeepEqual(testCase.expectedReqBody, bdy) {
+					if string(testCase.expectedReqBody) == string(bdy) {
+						// seems to be the cleanest way to check for
+						// nils while allowing the tester to skip
+						// byte arrays when not checking.
+					} else {
+						t.Errorf("expectedBody: %s but actual body: %s",
+							string(testCase.expectedReqBody), string(bdy))
+					}
+				}
+				w.WriteHeader(testCase.statusCode)
+				w.Write(testCase.response)
+			}))
+			defer ts.Close()
+
+			cl := NewClient(Config{BaseURL: ts.URL})
+			req, err := cl.NewRequest(Operation{HTTPMethod: testCase.method,
+				HTTPPath: testCase.path}, op, testCase.body, testCase.params)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if testCase.forceHTTPClientErr {
+				req.HTTPRequest.URL = nil
+			}
+
+			err = req.Send()
+			if err != nil {
+				if !isEqual(testCase.expectedErr, err) {
+					t.Errorf("expected :%v, actual: %v", testCase.expectedErr,
+						err)
+				}
+			}
+
+			actualOP := req.Output.(*basicOutputType)
+			assert.Equal(t, testCase.expectedOP, actualOP)
+
+		})
+	}
+}
+
+func isEqual(expectedErr error, actualErr error) bool {
+	if expectedErr == nil && actualErr == nil {
+		return true
+	}
+
+	if expectedErr == nil {
+		return false
+	}
+
+	if actualErr == nil {
+		return false
+	}
+
+	return expectedErr.Error() == actualErr.Error()
+
+}

--- a/client/retryer.go
+++ b/client/retryer.go
@@ -1,0 +1,111 @@
+package client
+
+import (
+	"math/rand"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// Retryer is an interface to control retry logic for a given service.
+type Retryer interface {
+	RetryRules(*Request) time.Duration
+	ShouldRetry(*Request) bool
+	MaxRetries() int
+}
+
+// DefaultRetryer implements basic retry logic using exponential backoff for
+// most services.
+type DefaultRetryer struct {
+	NumMaxRetries     int
+	MaxRetryThreshold int
+}
+
+// MaxRetries returns the number of maximum returns the service will use to make
+// an individual API
+func (d DefaultRetryer) MaxRetries() int {
+	return d.NumMaxRetries
+}
+
+var seededRand = rand.New(&lockedSource{src: rand.NewSource(time.Now().UnixNano())})
+
+// RetryRules returns the delay duration before retrying this request again
+func (d DefaultRetryer) RetryRules(r *Request) time.Duration {
+	// Set the upper limit of delay in retrying at ~five minutes
+	minTime := 30
+	maxRetryThreshold := d.MaxRetryThreshold
+	if maxRetryThreshold == 0 {
+		maxRetryThreshold = 8
+	}
+
+	retryCount := r.RetryCount
+	if retryCount > maxRetryThreshold {
+		retryCount = maxRetryThreshold
+	}
+
+	delay := (1 << uint(retryCount)) * (seededRand.Intn(minTime) + minTime)
+	return time.Duration(delay) * time.Millisecond
+}
+
+// ShouldRetry returns true if the request should be retried.
+func (d DefaultRetryer) ShouldRetry(r *Request) bool {
+	if r.HTTPResponse == nil {
+		return false
+	}
+	if r.HTTPResponse.StatusCode >= 500 {
+		return true
+	}
+	return false
+}
+
+// This will look in the Retry-After header, RFC 7231, for how long
+// it will wait before attempting another request
+func getRetryDelay(r *Request) (time.Duration, bool) {
+	if !canUseRetryAfterHeader(r) {
+		return 0, false
+	}
+
+	delayStr := r.HTTPResponse.Header.Get("Retry-After")
+	if len(delayStr) == 0 {
+		return 0, false
+	}
+
+	delay, err := strconv.Atoi(delayStr)
+	if err != nil {
+		return 0, false
+	}
+
+	return time.Duration(delay) * time.Second, true
+}
+
+// Will look at the status code to see if the retry header pertains to
+// the status code.
+func canUseRetryAfterHeader(r *Request) bool {
+	switch r.HTTPResponse.StatusCode {
+	case 429:
+	case 503:
+	default:
+		return false
+	}
+
+	return true
+}
+
+// lockedSource is a thread-safe implementation of rand.Source
+type lockedSource struct {
+	lk  sync.Mutex
+	src rand.Source
+}
+
+func (r *lockedSource) Int63() (n int64) {
+	r.lk.Lock()
+	n = r.src.Int63()
+	r.lk.Unlock()
+	return
+}
+
+func (r *lockedSource) Seed(seed int64) {
+	r.lk.Lock()
+	r.src.Seed(seed)
+	r.lk.Unlock()
+}

--- a/client/retryer_test.go
+++ b/client/retryer_test.go
@@ -1,0 +1,147 @@
+package client
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func Test_RetryRules(t *testing.T) {
+	testCases := []struct {
+		desc                          string
+		response                      *http.Response
+		retryCount                    int
+		expectedSleepTimeMinThreshold time.Duration
+		expectedSleepTimeMaxThreshold time.Duration
+	}{
+		{
+			desc: "backoff algorithm works for increased retries = 1",
+			response: &http.Response{
+				StatusCode: 429,
+			},
+			retryCount:                    5,
+			expectedSleepTimeMinThreshold: 500 * time.Millisecond,
+			expectedSleepTimeMaxThreshold: 4 * time.Second,
+		},
+		{
+			desc: "backoff algorithm works for increased retries = 2",
+			response: &http.Response{
+				StatusCode: 429,
+			},
+			retryCount:                    8,
+			expectedSleepTimeMinThreshold: 6 * time.Second,
+			expectedSleepTimeMaxThreshold: 20 * time.Second,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.desc, func(t *testing.T) {
+			d := DefaultRetryer{NumMaxRetries: 3}
+			r := &Request{HTTPResponse: testCase.response,
+				RetryCount: testCase.retryCount}
+
+			timeSecs := d.RetryRules(r)
+
+			if timeSecs < testCase.expectedSleepTimeMinThreshold {
+				t.Errorf("timesecs %v below expected min threshold: %v",
+					timeSecs, testCase.expectedSleepTimeMinThreshold)
+			}
+
+			if timeSecs > testCase.expectedSleepTimeMaxThreshold {
+				t.Errorf("timesecs %v above expected max threshold: %v",
+					timeSecs, testCase.expectedSleepTimeMaxThreshold)
+			}
+		})
+	}
+}
+
+func TestCanUseRetryAfter(t *testing.T) {
+	testCases := []struct {
+		r *Request
+		e bool
+	}{
+		{
+			&Request{
+				HTTPResponse: &http.Response{StatusCode: 200},
+			},
+			false,
+		},
+		{
+			&Request{
+				HTTPResponse: &http.Response{StatusCode: 500},
+			},
+			false,
+		},
+		{
+			&Request{
+				HTTPResponse: &http.Response{StatusCode: 429},
+			},
+			true,
+		},
+		{
+			&Request{
+				HTTPResponse: &http.Response{StatusCode: 503},
+			},
+			true,
+		},
+	}
+
+	for i, c := range testCases {
+		a := canUseRetryAfterHeader(c.r)
+		if c.e != a {
+			t.Errorf("%d: expected %v, but received %v", i, c.e, a)
+		}
+	}
+}
+
+func TestGetRetryDelay(t *testing.T) {
+	testCases := []struct {
+		r     *Request
+		e     time.Duration
+		equal bool
+		ok    bool
+	}{
+		{
+			&Request{
+				HTTPResponse: &http.Response{StatusCode: 429, Header: http.Header{"Retry-After": []string{"3600"}}},
+			},
+			3600 * time.Second,
+			true,
+			true,
+		},
+		{
+			&Request{
+				HTTPResponse: &http.Response{StatusCode: 503, Header: http.Header{"Retry-After": []string{"120"}}},
+			},
+			120 * time.Second,
+			true,
+			true,
+		},
+		{
+			&Request{
+				HTTPResponse: &http.Response{StatusCode: 503, Header: http.Header{"Retry-After": []string{"120"}}},
+			},
+			1 * time.Second,
+			false,
+			true,
+		},
+		{
+			&Request{
+				HTTPResponse: &http.Response{StatusCode: 503, Header: http.Header{"Retry-After": []string{""}}},
+			},
+			0 * time.Second,
+			true,
+			false,
+		},
+	}
+
+	for i, c := range testCases {
+		a, ok := getRetryDelay(c.r)
+		if c.ok != ok {
+			t.Errorf("%d: expected %v, but received %v", i, c.ok, ok)
+		}
+
+		if (c.e != a) == c.equal {
+			t.Errorf("%d: expected %v, but received %v", i, c.e, a)
+		}
+	}
+}

--- a/client/safereader.go
+++ b/client/safereader.go
@@ -1,0 +1,51 @@
+package client
+
+import (
+	"io"
+	"sync"
+)
+
+// offsetReader is a thread-safe io.ReadCloser to prevent racing
+// with retrying requests
+type offsetReader struct {
+	buf    io.ReadSeeker
+	lock   sync.Mutex
+	closed bool
+}
+
+func newOffsetReader(buf io.ReadSeeker, offset int64) *offsetReader {
+	reader := &offsetReader{}
+	buf.Seek(offset, 0)
+
+	reader.buf = buf
+	return reader
+}
+
+// Close will close the instance of the offset reader's access to
+// the underlying io.ReadSeeker.
+func (o *offsetReader) Close() error {
+	o.lock.Lock()
+	defer o.lock.Unlock()
+	o.closed = true
+	return nil
+}
+
+// Read is a thread-safe read of the underlying io.ReadSeeker
+func (o *offsetReader) Read(p []byte) (int, error) {
+	o.lock.Lock()
+	defer o.lock.Unlock()
+
+	if o.closed {
+		return 0, io.EOF
+	}
+
+	return o.buf.Read(p)
+}
+
+// Seek is a thread-safe seeking operation.
+func (o *offsetReader) Seek(offset int64, whence int) (int64, error) {
+	o.lock.Lock()
+	defer o.lock.Unlock()
+
+	return o.buf.Seek(offset, whence)
+}

--- a/client/safereader_test.go
+++ b/client/safereader_test.go
@@ -1,0 +1,118 @@
+package client
+
+import (
+	"bytes"
+	"io"
+	"math/rand"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestOffsetReaderRead(t *testing.T) {
+	buf := []byte("testData")
+	reader := &offsetReader{buf: bytes.NewReader(buf)}
+
+	tempBuf := make([]byte, len(buf))
+
+	n, err := reader.Read(tempBuf)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if n != len(buf) {
+		t.Errorf("lengths don't match. expected: %d, actual: %d",
+			n, len(buf))
+	}
+
+	if !reflect.DeepEqual(buf, tempBuf) {
+		t.Errorf("bufs not equal. expected: %v, actual: %v", buf, tempBuf)
+	}
+}
+
+func TestOffsetReaderSeek(t *testing.T) {
+	buf := []byte("testData")
+	reader := newOffsetReader(bytes.NewReader(buf), 0)
+
+	n, err := reader.Seek(0, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if int64(len(buf)) != n {
+		t.Error("seek does not do so on offset")
+	}
+}
+
+func TestOffsetReaderClose(t *testing.T) {
+	buf := []byte("testData")
+	reader := &offsetReader{buf: bytes.NewReader(buf)}
+
+	err := reader.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tempBuf := make([]byte, len(buf))
+	n, err := reader.Read(tempBuf)
+	if n != 0 {
+		t.Error("bytes read should be 0 for EOF")
+	}
+	if !reflect.DeepEqual(err, io.EOF) {
+		t.Error("EOF error is not seen")
+	}
+}
+
+func TestOffsetReaderRace(t *testing.T) {
+	wg := sync.WaitGroup{}
+
+	f := func(reader *offsetReader) {
+		defer wg.Done()
+		var err error
+		buf := make([]byte, 1)
+		_, err = reader.Read(buf)
+		for err != io.EOF {
+			_, err = reader.Read(buf)
+		}
+
+	}
+
+	closeFn := func(reader *offsetReader) {
+		defer wg.Done()
+		time.Sleep(time.Duration(rand.Intn(20)+1) * time.Millisecond)
+		reader.Close()
+	}
+	for i := 0; i < 50; i++ {
+		reader := &offsetReader{buf: bytes.NewReader(make([]byte, 1024*1024))}
+		wg.Add(1)
+		go f(reader)
+		wg.Add(1)
+		go closeFn(reader)
+	}
+	wg.Wait()
+}
+
+func BenchmarkOffsetReader(b *testing.B) {
+	bufSize := 1024 * 1024 * 100
+	buf := make([]byte, bufSize)
+	reader := &offsetReader{buf: bytes.NewReader(buf)}
+
+	tempBuf := make([]byte, 1024)
+
+	for i := 0; i < b.N; i++ {
+		reader.Read(tempBuf)
+	}
+}
+
+func BenchmarkBytesReader(b *testing.B) {
+	bufSize := 1024 * 1024 * 100
+	buf := make([]byte, bufSize)
+	reader := bytes.NewReader(buf)
+
+	tempBuf := make([]byte, 1024)
+
+	for i := 0; i < b.N; i++ {
+		reader.Read(tempBuf)
+	}
+}

--- a/client/unmarshaler.go
+++ b/client/unmarshaler.go
@@ -1,0 +1,28 @@
+package client
+
+import (
+	"encoding/json"
+	"io"
+)
+
+var unmarshalers = map[string]Unmarshaler{
+	"application/json": &jsonUnmarshaler{},
+}
+
+// AddUnmarshaler can add any unmarshaler to the list of accepted unmarshalers
+// by client.
+func AddUnmarshaler(header string, unmarshaler Unmarshaler) {
+	unmarshalers[header] = unmarshaler
+}
+
+// Unmarshaler is the specification every accept header type needs to implement
+// to be able to unmarshal the registered type.
+type Unmarshaler interface {
+	Unmarshal(r io.Reader, v interface{}) error
+}
+
+type jsonUnmarshaler struct{}
+
+func (j *jsonUnmarshaler) Unmarshal(r io.Reader, v interface{}) error {
+	return json.NewDecoder(r).Decode(v)
+}


### PR DESCRIPTION
## What this PR does

- Creates an internal http client that keeps a client pool to make requests.
- Adds a pluggable authorizer interface
- Adds a pluggable retryer interface
- Adds a pluggable logger interface
- Adds a pluggable unmarshaler interface

Addresses https://github.com/Routefusion/routefusion-golang/issues/4